### PR TITLE
Extensions to support NaN handling in QRF

### DIFF
--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -25,6 +25,8 @@ from improver.utilities.cube_manipulation import MergeCubes
 from improver.utilities.flatten import flatten
 from improver.utilities.load import load_cubelist
 
+iris.FUTURE.pandas_ndim = True
+
 
 class CalibrationSchemas:
     def __init__(self):

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -611,6 +611,11 @@ def add_static_feature_from_cube_to_df(
         forecast_df: DataFrame containing the forecast data.
         cube_inputs: List of cubes containing additional features.
         feature_name: Name of the feature to be added.
+        possible_merge_columns: List of column names that can be used to merge
+            the feature DataFrame to the forecast DataFrame.
+        float_decimals: Number of decimal places to round float columns to
+            before merging. Default is 4, which corresponds to rounding to
+            0.0001.
     Returns:
         DataFrame with additional feature added from the input cubes.
     """

--- a/improver/calibration/__init__.py
+++ b/improver/calibration/__init__.py
@@ -623,9 +623,10 @@ def add_static_feature_from_cube_to_df(
 
     merge_columns = [col for col in possible_merge_columns if col in feature_df.columns]
 
+    # Select the required DataFrame subset using the merge_columns and dtypes.
     # Columns with any NaNs can not be converted to integers, and therefore are left
     # unmodified.
-    float_subset = feature_df.select_dtypes(include=[np.float32])
+    float_subset = feature_df[merge_columns].select_dtypes(include=[np.float32])
     float_subset = float_subset[float_subset.columns[~float_subset.isnull().any()]]
 
     float_cols = list(set(float_subset.columns).intersection(set(forecast_df.columns)))

--- a/improver/calibration/load_and_apply_quantile_regression_random_forest.py
+++ b/improver/calibration/load_and_apply_quantile_regression_random_forest.py
@@ -16,7 +16,7 @@ from iris.cube import Cube, CubeList
 from iris.pandas import as_data_frame
 
 from improver import PostProcessingPlugin
-from improver.calibration import add_warning_comment
+from improver.calibration import add_static_feature_from_cube_to_df, add_warning_comment
 from improver.calibration.quantile_regression_random_forest import (
     ApplyQuantileRegressionRandomForests,
     quantile_forest_package_available,
@@ -254,14 +254,11 @@ class PrepareAndApplyQRF(PostProcessingPlugin):
 
         # Iteratively convert remaining cubes to DataFrame and merge.
         for cube in cube_inputs[1:]:
-            temporary_df = as_data_frame(cube, add_aux_coords=True).reset_index()
-            merge_columns = [
-                col for col in possible_columns if col in temporary_df.columns
-            ]
-            df = df.merge(
-                temporary_df[merge_columns + [cube.name()]],
-                on=merge_columns,
-                how="left",
+            df = add_static_feature_from_cube_to_df(
+                df,
+                cube,
+                cube.name(),
+                possible_columns,
             )
 
         for column in ["forecast_reference_time", "time"]:

--- a/improver/calibration/load_and_train_quantile_regression_random_forest.py
+++ b/improver/calibration/load_and_train_quantile_regression_random_forest.py
@@ -35,9 +35,6 @@ except ModuleNotFoundError:
         pass
 
 
-iris.FUTURE.pandas_ndim = True
-
-
 class LoadForTrainQRF(PostProcessingPlugin):
     """Plugin to load input files for training a Quantile Regression Random Forest
     (QRF) model."""

--- a/improver/calibration/load_and_train_quantile_regression_random_forest.py
+++ b/improver/calibration/load_and_train_quantile_regression_random_forest.py
@@ -13,11 +13,11 @@ from typing import Optional, Union
 import iris
 import numpy as np
 import pandas as pd
-from iris.pandas import as_data_frame
 
 from improver import PostProcessingPlugin
 from improver.calibration import (
     CalibrationSchemas,
+    add_static_feature_from_cube_to_df,
     get_training_period_cycles,
     identify_parquet_type,
     split_netcdf_parquet_pickle,
@@ -442,46 +442,6 @@ class PrepareAndTrainQRF(PostProcessingPlugin):
             )
         )
 
-    def _add_static_feature_from_cube_to_df(
-        self, forecast_df: pd.DataFrame, feature_cube: iris.cube.Cube, feature_name: str
-    ) -> pd.DataFrame:
-        """Add a static feature to the forecast DataFrame from a cube based on the
-        feature configuration. Other features are expected to already be present in the
-        forecast DataFrame. Columns that are float, after converting from a Cube to a
-        DataFrame, are rounded to a specified number of decimal places before merging
-        to avoid precision issues.
-
-        Args:
-            forecast_df: DataFrame containing the forecast data.
-            cube_inputs: List of cubes containing additional features.
-            feature_name: Name of the feature to be added.
-        Returns:
-            DataFrame with additional feature added from the input cubes.
-        """
-        feature_df = as_data_frame(feature_cube, add_aux_coords=True)
-        multiplier = 10**self.float_decimals
-        float_subset = feature_df.select_dtypes(include=[np.float32])
-        float_cols = list(
-            set(float_subset.columns).intersection(set(forecast_df.columns))
-        )
-        feature_df[float_cols] = np.round(feature_df[float_cols] * multiplier).astype(
-            int
-        )
-
-        original_dtypes = forecast_df[float_cols].dtypes
-        forecast_df[float_cols] = np.round(forecast_df[float_cols] * multiplier).astype(
-            int
-        )
-
-        forecast_df = forecast_df.merge(
-            feature_df[[*self.unique_site_id_keys, feature_name]],
-            on=[*self.unique_site_id_keys],
-            how="left",
-        )
-        for col, dtype in zip(float_cols, original_dtypes):
-            forecast_df[col] = forecast_df[col].astype(dtype) / multiplier
-        return forecast_df
-
     def _add_static_features_from_cubes_to_df(
         self, forecast_df: pd.DataFrame, cube_inputs: iris.cube.CubeList
     ) -> pd.DataFrame:
@@ -512,8 +472,12 @@ class PrepareAndTrainQRF(PostProcessingPlugin):
                         feature_cube = None
                     if not feature_cube:
                         continue
-                    forecast_df = self._add_static_feature_from_cube_to_df(
-                        forecast_df, feature_cube, feature_name
+                    forecast_df = add_static_feature_from_cube_to_df(
+                        forecast_df,
+                        feature_cube,
+                        feature_name,
+                        [*self.unique_site_id_keys],
+                        float_decimals=self.float_decimals,
                     )
         return forecast_df
 

--- a/improver/calibration/quantile_regression_random_forest.py
+++ b/improver/calibration/quantile_regression_random_forest.py
@@ -69,6 +69,8 @@ def prep_feature(
             each site, e.g. "wmo_id" or ["latitude", "longitude"].
     Returns:
         df: DataFrame with the computed feature added.
+    Raises:
+        ValueError: If all computed values for the feature are NaN.
     """
     if (
         feature_name in ["mean", "std", "min", "max"]
@@ -136,6 +138,13 @@ def prep_feature(
             subset_df[variable_name] = subset_df[variable_name].astype(orig_dtype)
 
         subset_df = subset_df.reset_index()
+
+        if subset_df[variable_name].isnull().all():
+            msg = (
+                f"All computed values for feature '{feature_name}' "
+                f"and variable '{variable_name}' are NaN."
+            )
+            raise ValueError(msg)
         # Rename the column to distinguish the computed feature from the original.
         subset_df.rename(
             columns={variable_name: f"{variable_name}_{feature_name}"}, inplace=True

--- a/improver/calibration/quantile_regression_random_forest.py
+++ b/improver/calibration/quantile_regression_random_forest.py
@@ -245,6 +245,7 @@ def _drop_nans_from_forecast_df(
         forecast_df: Input forecast DataFrame.
         merge_columns: Columns used for merging forecast and truth DataFrames.
         feature_column_names: Names of the feature columns.
+        valid_forecast_proportion: Proportion of forecast data that can be removed.
     Raises:
         ValueError: If more than the specific proportion of the forecast data has been
         removed after dropping NaNs.

--- a/improver/calibration/quantile_regression_random_forest.py
+++ b/improver/calibration/quantile_regression_random_forest.py
@@ -139,6 +139,11 @@ def prep_feature(
 
         subset_df = subset_df.reset_index()
 
+        if feature_name == "std" and subset_df[variable_name].isnull().any():
+            # If all values are identical for a group, std will be NaN.
+            # Replace these NaNs with 0.
+            subset_df[variable_name] = subset_df[variable_name].fillna(value=0)
+
         if subset_df[variable_name].isnull().all():
             msg = (
                 f"All computed values for feature '{feature_name}' "

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_apply_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_apply_quantile_regression_random_forest.py
@@ -230,19 +230,19 @@ def set_up_for_expected(
 @pytest.mark.parametrize(
     "n_estimators,max_depth,random_state,transformation,pre_transform_addition,extra_kwargs,include_dynamic,include_static,include_nans,include_latlon_nans,quantiles,expected",
     [
-        (2, 2, 55, None, 0, {}, False, False, False, False, [0.5], [4.1, 5.15]),  # Basic test case
+        (2, 2, 55, None, 0, {}, False, False, False, False, [0.5], [4.1, 5.65]),  # Basic test case
         (100, 2, 55, None, 0, {}, False, False, False, False, [1 / 3, 2 / 3], [[4.1, 5.1], [5.1, 5.1]]),  # Multiple quantiles
         (1, 1, 55, None, 0, {}, False, False, False, False, [0.5], [4.1, 6.2]),  # Fewer estimators and reduced depth
         (1, 1, 73, None, 0, {}, False, False, False, False, [0.5], [4.2, 6.2]),  # Different random state
-        (2, 2, 55, "log", 10, {}, False, False, False, False, [0.5], [4.1, 5.64]),  # Log transformation
-        (2, 2, 55, "log10", 10, {}, False, False, False, False, [0.5], [4.1, 5.64]),  # Log10 transformation
-        (2, 2, 55, "sqrt", 10, {}, False, False, False, False, [0.5], [4.1, 5.64]),  # Square root transformation
-        (2, 2, 55, "cbrt", 10, {}, False, False, False, False, [0.5], [4.1, 5.64]),  # Cube root transformation
-        (2, 2, 55, None, 0, {"max_samples_leaf": 0.5}, False, False, False, False, [0.5], [4.1, 5.15]),  # Different criterion
-        (2, 5, 55, None, 0, {}, True, False, False, False, [0.5], [4.1, 5.15]),  # Include an additional dynamic feature
+        (2, 2, 55, "log", 10, {}, False, False, False, False, [0.5], [4.1, 5.1]),  # Log transformation
+        (2, 2, 55, "log10", 10, {}, False, False, False, False, [0.5], [4.1, 5.1]),  # Log10 transformation
+        (2, 2, 55, "sqrt", 10, {}, False, False, False, False, [0.5], [4.1, 5.1]),  # Square root transformation
+        (2, 2, 55, "cbrt", 10, {}, False, False, False, False, [0.5], [4.1, 5.1]),  # Cube root transformation
+        (2, 2, 55, None, 0, {"max_samples_leaf": 0.5}, False, False, False, False, [0.5], [4.1, 6.2]),  # Different criterion
+        (2, 5, 55, None, 0, {}, True, False, False, False, [0.5], [4.1, 4.6]),  # Include an additional dynamic feature
         (2, 5, 55, None, 0, {}, False, True, False, False, [0.5], [4.1, 5.65]),  # Include an additional static feature
-        (2, 5, 55, None, 0, {}, True, True, False, False, [0.5], [4.1, 5.65]),  # Include an additional dynamic and static feature
-        (2, 2, 55, None, 0, {}, False, False, True, False, [0.5], [4.6, 5.15]),  # NaNs in input data
+        (2, 5, 55, None, 0, {}, True, True, False, False, [0.5], [4.1, 4.6]),  # Include an additional dynamic and static feature
+        (2, 2, 55, None, 0, {}, False, False, True, False, [0.5], [4.1, 5.65]),  # NaNs in input data
         (2, 2, 55, None, 0, {}, False, False, False, True, [0.5], [4.1]),  # NaNs in lat/lon
         (2, 2, 55, None, 0, {}, True, False, False, True, [0.5], [4.1]),  # NaNs in lat/lon and dynamic feature
         (2, 2, 55, None, 0, {}, False, True, False, True, [0.5], [4.1]),  # NaNs in lat/lon and static feature
@@ -268,10 +268,10 @@ def test_prepare_and_apply_qrf(
     expected
 ):
     """Test the PrepareAndApplyQRF plugin."""
-    feature_config = {"wind_speed_at_10m": ["mean", "latitude", "longitude"]}
+    feature_config = {"wind_speed_at_10m": ["mean", "std", "latitude", "longitude"]}
 
     if include_dynamic:
-        feature_config["air_temperature"] = ["mean"]
+        feature_config["air_temperature"] = ["mean", "std"]
     if include_static:
         feature_config["distance_to_water"] = ["static"]
 
@@ -325,12 +325,12 @@ def test_prepare_and_apply_qrf(
 @pytest.mark.parametrize(
     "n_estimators,max_depth,random_state,cycletime,include_dynamic,include_static,add_fp_bounds,expected",
     [
-        (2, 2, 55, None, False, False, False, [4.1, 5.15]),  # Basic test case
-        (2, 2, 55, "20170103T0000Z", False, False, False, [4.1, 5.15]),  # Specify cycletime
-        (2, 2, 55, "20170102T2300Z", True, False, False, [4.1, 5.15]),  # Cycletime with dynamic feature
+        (2, 2, 55, None, False, False, False, [4.1, 5.65]),  # Basic test case
+        (2, 2, 55, "20170103T0000Z", False, False, False, [4.1, 5.65]),  # Specify cycletime
+        (2, 2, 55, "20170102T2300Z", True, False, False, [4.1, 4.6]),  # Cycletime with dynamic feature
         (2, 2, 55, "20170102T2300Z", False, True, False, [4.1, 5.65]),  # Cycletime with static feature
-        (2, 2, 55, "20170102T2300Z", True, True, False, [4.1, 5.65]),  # Cycletime with dynamic and static feature
-        (2, 2, 55, "20170102T2300Z", True, False, True, [4.1, 5.15]),  # Cycletime with dynamic feature and forecast period bounds
+        (2, 2, 55, "20170102T2300Z", True, True, False, [4.1, 4.6]),  # Cycletime with dynamic and static feature
+        (2, 2, 55, "20170102T2300Z", True, False, True, [4.1, 4.6]),  # Cycletime with dynamic feature and forecast period bounds
     ],
 )
 def test_mismatching_temporal_coordinates(
@@ -353,7 +353,7 @@ def test_mismatching_temporal_coordinates(
     The forecast reference time and forecast period on the resulting cube,
     are however, unchanged, because these are taken from the input target feature cube
     without modification."""
-    feature_config = {"wind_speed_at_10m": ["mean", "latitude", "longitude"]}
+    feature_config = {"wind_speed_at_10m": ["mean", "std", "latitude", "longitude"]}
     transformation = None
     pre_transform_addition = 0
     extra_kwargs = {}
@@ -368,7 +368,7 @@ def test_mismatching_temporal_coordinates(
         forecast_period = forecast_period * 3600
 
     if include_dynamic:
-        feature_config["air_temperature"] = ["mean"]
+        feature_config["air_temperature"] = ["mean", "std"]
     if include_static:
         feature_config["distance_to_water"] = ["static"]
 
@@ -499,7 +499,7 @@ def test_unused_static_feature():
     site_id = ["wmo_id"]
     quantiles = [0.5]
     feature_config = {
-        "wind_speed_at_10m": ["mean", "latitude", "longitude"],
+        "wind_speed_at_10m": ["mean", "std", "latitude", "longitude"],
     }
     qrf_model, cube_inputs = set_up_for_expected(
         feature_config, n_estimators, max_depth, random_state,

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
@@ -886,7 +886,7 @@ def test_prepare_and_train_qrf(
     forecast_periods,
 ):
     """Test the PrepareAndTrainQRF plugin."""
-    feature_config = {"air_temperature": ["mean", "altitude"]}
+    feature_config = {"air_temperature": ["mean", "std", "altitude"]}
     n_estimators = 2
     max_depth = 5
     random_state = 46
@@ -910,7 +910,7 @@ def test_prepare_and_train_qrf(
 
     if include_dynamic:
         forecast_df["wind_speed"] = [10.0, 20.0, 15.0, 12.0, 11.0][: len(forecast_df)]
-        feature_config["wind_speed"] = ["mean"]
+        feature_config["wind_speed"] = ["mean", "std"]
 
     if include_static:
         _, ancil_cube = _create_ancil_file(
@@ -978,13 +978,13 @@ def test_prepare_and_train_qrf(
     assert transformation == "log"
     assert pre_transform_addition == 1
 
-    current_forecast = [5.64, 55]
+    current_forecast = [5.64, 3, 55]
 
     if remove_target:
         current_forecast = []
 
     if include_dynamic:
-        current_forecast.extend([7])
+        current_forecast.extend([7, 1])
 
     if include_noncube_static:
         current_forecast.append(100)

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
@@ -22,6 +22,27 @@ ALTITUDE = [10, 20]
 LATITUDE = [50, 60]
 LONGITUDE = [0, 10]
 SITE_ID = ["03001", "03002", "03003", "03004", "03005"]
+LATITUDE_LOOKUP = {
+    "03001": 60.1,
+    "03002": 59.9,
+    "03003": 59.7,
+    "03004": 58.0,
+    "03005": 57.0,
+}
+LONGITUDE_LOOKUP = {
+    "03001": 1.0,
+    "03002": 2.0,
+    "03003": -1.0,
+    "03004": -2.0,
+    "03005": -3.0,
+}
+ALTITUDE_LOOKUP = {
+    "03001": 10.0,
+    "03002": 83.0,
+    "03003": 56.0,
+    "03004": 23.0,
+    "03005": 2.0,
+}
 
 
 def write_to_parquet(df, tmp_path, dirname, filename):
@@ -129,19 +150,19 @@ def _create_multi_site_forecast_parquet_file(tmp_path, representation=None):
             "percentile", "realization" or "kittens". "kittens" is just
             used for testing that the code works with a non-standard name.
     """
-
+    wmo_ids = ["03001", "03002", "03003", "03004", "03005"]
     data_dict = {
         "percentile": np.repeat(50.0, 5),
         "forecast": [281.0, 272.0, 287.0, 280.0, 290.0],
-        "altitude": [10.0, 83.0, 56.0, 23.0, 2.0],
+        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
         "blend_time": [pd.Timestamp("2017-01-02 00:00:00", tz="utc")] * 5,
         "forecast_period": [6 * 3.6e12] * 5,
         "forecast_reference_time": [pd.Timestamp("2017-01-02 00:00:00", tz="utc")] * 5,
-        "latitude": [60.1, 59.9, 59.7, 58, 57],
-        "longitude": [1.0, 2.0, -1.0, -2.0, -3.0],
+        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
         "time": [pd.Timestamp("2017-01-02 06:00:00", tz="utc")] * 5,
-        "wmo_id": ["03001", "03002", "03003", "03004", "03005"],
-        "station_id": ["03001", "03002", "03003", "03004", "03005"],
+        "wmo_id": wmo_ids,
+        "station_id": [f"{int(_id):08}" for _id in wmo_ids],
         "cf_name": ["air_temperature"] * 5,
         "units": ["K"] * 5,
         "experiment": ["latestblend"] * 5,
@@ -174,19 +195,19 @@ def _create_multi_percentile_forecast_parquet_file(tmp_path, representation=None
             "percentile" (default), "realization" or "kittens". "kittens" is just
             used for testing that the code works with a non-standard name.
     """
-
+    wmo_ids = ["03001"] * 5
     data_dict = {
         "percentile": [16 + 2 / 3, 33 + 1 / 3, 50, 66 + 2 / 3, 83 + 1 / 3],
         "forecast": [272.0, 274.0, 275.0, 277.0, 280.0],
-        "altitude": [10.0, 10.0, 10.0, 10.0, 10.0],
+        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
         "blend_time": [pd.Timestamp("2017-01-02 00:00:00", tz="utc")] * 5,
         "forecast_period": [6 * 3.6e12] * 5,
         "forecast_reference_time": [pd.Timestamp("2017-01-02 00:00:00", tz="utc")] * 5,
-        "latitude": [60.1, 60.1, 60.1, 60.1, 60.1],
-        "longitude": [1, 1, 1, 1, 1],
+        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
         "time": [pd.Timestamp("2017-01-02 06:00:00", tz="utc")] * 5,
-        "wmo_id": ["03001", "03001", "03001", "03001", "03001"],
-        "station_id": ["03001", "03001", "03001", "03001", "03001"],
+        "wmo_id": wmo_ids,
+        "station_id": [f"{int(_id):08}" for _id in wmo_ids],
         "cf_name": ["air_temperature"] * 5,
         "units": ["K"] * 5,
         "experiment": ["latestblend"] * 5,
@@ -219,11 +240,11 @@ def _create_multi_forecast_period_forecast_parquet_file(tmp_path, representation
             "percentile", "realization" or "kittens". "kittens" is just
             used for testing that the code works with a non-standard name.
     """
-
+    wmo_ids = ["03001", "03002", "03001", "03002"]
     data_dict = {
         "percentile": [50.0, 50.0, 50.0, 50.0],
         "forecast": [277.0, 270.0, 280.0, 269.0],
-        "altitude": [10.0, 83.0, 10.0, 83.0],
+        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
         "blend_time": [pd.Timestamp("2017-01-02 00:00:00")] * 4,
         "forecast_period": np.repeat(
             [
@@ -233,14 +254,14 @@ def _create_multi_forecast_period_forecast_parquet_file(tmp_path, representation
             2,
         ),
         "forecast_reference_time": [pd.Timestamp("2017-01-02 00:00:00")] * 4,
-        "latitude": [60.1, 59.9, 60.1, 59.9],
-        "longitude": [1, 2, 1, 2],
+        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
         "time": np.repeat(
             [pd.Timestamp("2017-01-02 06:00:00"), pd.Timestamp("2017-01-02 12:00:00")],
             2,
         ),
-        "wmo_id": ["03001", "03002", "03001", "03002"],
-        "station_id": ["03001", "03002", "03001", "03002"],
+        "wmo_id": wmo_ids,
+        "station_id": [f"{int(_id):08}" for _id in wmo_ids],
         "cf_name": ["air_temperature"] * 4,
         "units": ["K"] * 4,
         "experiment": ["latestblend"] * 4,
@@ -260,14 +281,15 @@ def _create_multi_forecast_period_forecast_parquet_file(tmp_path, representation
 
 def _create_multi_site_truth_parquet_file(tmp_path):
     """Create a parquet file with multi-site truth data."""
+    wmo_ids = ["03001", "03002", "03003", "03004", "03005"]
     data_dict = {
         "diagnostic": ["temperature_at_screen_level"] * 5,
-        "latitude": [60.1, 59.9, 59.7, 58, 57],
-        "longitude": [1.0, 2.0, -1.0, -2.0, -3.0],
-        "altitude": [10.0, 83.0, 56.0, 23.0, 2.0],
+        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
         "time": [pd.Timestamp("2017-01-02 06:00:00")] * 5,
-        "wmo_id": ["03001", "03002", "03003", "03004", "03005"],
-        "station_id": ["03001", "03002", "03003", "03004", "03005"],
+        "wmo_id": wmo_ids,
+        "station_id": [f"{int(_id):08}" for _id in wmo_ids],
         "ob_value": [276.0, 270.0, 289.0, 290.0, 301.0],
     }
     joined_df = add_wind_data_to_truth(data_dict, [3, 22, 24, 11, 9])
@@ -286,7 +308,7 @@ def _create_multi_percentile_truth_parquet_file(tmp_path):
         "altitude": [10.0],
         "time": [pd.Timestamp("2017-01-02 06:00:00")],
         "wmo_id": ["03001"],
-        "station_id": ["03001"],
+        "station_id": ["00003001"],
         "ob_value": [276.0],
     }
     joined_df = add_wind_data_to_truth(data_dict, [9])
@@ -298,17 +320,18 @@ def _create_multi_percentile_truth_parquet_file(tmp_path):
 
 def _create_multi_forecast_period_truth_parquet_file(tmp_path):
     """Create a parquet file with multi-forecast period truth data."""
+    wmo_ids = ["03001", "03002", "03001", "03002"]
     data_dict = {
         "diagnostic": ["temperature_at_screen_level"] * 4,
-        "latitude": [60.1, 59.9, 60.1, 59.9],
-        "longitude": [1.0, 2.0, 1.0, 2.0],
-        "altitude": [10.0, 83.0, 10.0, 83.0],
+        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
         "time": np.repeat(
             [pd.Timestamp("2017-01-02 06:00:00"), pd.Timestamp("2017-01-02 12:00:00")],
             2,
         ),
-        "wmo_id": ["03001", "03002", "03001", "03002"],
-        "station_id": ["03001", "03002", "03001", "03002"],
+        "wmo_id": wmo_ids,
+        "station_id": [f"{int(_id):08}" for _id in wmo_ids],
         "ob_value": [280, 273, 284, 275],
     }
     joined_df = add_wind_data_to_truth(data_dict, [2.0, 11.0, 10.0, 14.0])
@@ -320,14 +343,15 @@ def _create_multi_forecast_period_truth_parquet_file(tmp_path):
 
 def _create_multi_site_truth_parquet_file_alt(tmp_path, site_id="wmo_id"):
     """Create a parquet file with multi-site truth data for wind speed."""
+    wmo_ids = ["03001", "03002", "03003", "03004", "03005"]
     data_dict = {
         "diagnostic": ["wind_speed_at_10m"] * 5,
-        "latitude": [60.1, 59.9, 59.7, 58, 57],
-        "longitude": [1.0, 2.0, -1.0, -2.0, -3.0],
-        "altitude": [10.0, 83.0, 56.0, 23.0, 2.0],
+        "latitude": [LATITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "longitude": [LONGITUDE_LOOKUP[_id] for _id in wmo_ids],
+        "altitude": [ALTITUDE_LOOKUP[_id] for _id in wmo_ids],
         "time": [pd.Timestamp("2017-01-02 06:00:00")] * 5,
-        "wmo_id": ["03001", "03002", "03003", "03004", "03005"],
-        "station_id": ["03001", "03002", "03003", "03004", "03005"],
+        "wmo_id": wmo_ids,
+        "station_id": [f"{int(_id):08}" for _id in wmo_ids],
         "ob_value": [10.0, 25.0, 4.0, 3.0, 11.0],
     }
     joined_df = add_wind_data_to_truth(data_dict, [3.0, 22.0, 24.0, 11.0, 9.0])
@@ -344,14 +368,21 @@ def _create_ancil_file(tmp_path, site_ids):
         An ancillary cube with a single value.
     """
     data = np.array(range(len(site_ids)), dtype=np.float32)
+    latitudes = np.array([LATITUDE_LOOKUP[_id] for _id in site_ids], dtype=np.float32)
+    longitudes = np.array([LONGITUDE_LOOKUP[_id] for _id in site_ids], dtype=np.float32)
+    altitudes = np.array([ALTITUDE_LOOKUP[_id] for _id in site_ids], dtype=np.float32)
     template_cube = set_up_spot_variable_cube(
         data,
+        latitudes=latitudes,
+        longitudes=longitudes,
+        altitudes=altitudes,
         wmo_ids=site_ids,
         unique_site_id=site_ids,
         unique_site_id_key="station_id",
         name="distance_to_water",
         units="m",
     )
+
     cube = template_cube.copy()
     for coord in ["time", "forecast_reference_time", "forecast_period"]:
         cube.remove_coord(coord)
@@ -855,7 +886,7 @@ def test_prepare_and_train_qrf(
     forecast_periods,
 ):
     """Test the PrepareAndTrainQRF plugin."""
-    feature_config = {"air_temperature": ["mean", "std", "altitude"]}
+    feature_config = {"air_temperature": ["mean", "altitude"]}
     n_estimators = 2
     max_depth = 5
     random_state = 46
@@ -879,10 +910,13 @@ def test_prepare_and_train_qrf(
 
     if include_dynamic:
         forecast_df["wind_speed"] = [10.0, 20.0, 15.0, 12.0, 11.0][: len(forecast_df)]
-        feature_config["wind_speed"] = ["mean", "std"]
+        feature_config["wind_speed"] = ["mean"]
 
     if include_static:
-        _, ancil_cube = _create_ancil_file(tmp_path, sorted(list(set(site_ids))))
+        _, ancil_cube = _create_ancil_file(
+            tmp_path,
+            sorted(list(set(site_ids))),
+        )
         feature_config["distance_to_water"] = ["static"]
 
     if include_noncube_static:
@@ -944,13 +978,13 @@ def test_prepare_and_train_qrf(
     assert transformation == "log"
     assert pre_transform_addition == 1
 
-    current_forecast = [5.64, 3, 55]
+    current_forecast = [5.64, 55]
 
     if remove_target:
         current_forecast = []
 
     if include_dynamic:
-        current_forecast.extend([7, 1])
+        current_forecast.extend([7])
 
     if include_noncube_static:
         current_forecast.append(100)

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_quantile_regression_random_forest.py
@@ -362,20 +362,20 @@ def test_prep_feature_invalid_percentiles(scenario):
         prep_feature(forecast_df, variable_name, "mean")
 
 
-def test_prep_feature_std_exception():
-    """Test that an error is raised if invalid percentiles are provided."""
+def test_prep_feature_nan_exception():
+    """Test that an error is raised if the computed features are NaN."""
     variable_name = "wind_speed_at_10m"
 
     forecast_reference_time = "20170101T0000Z"
     validity_time = "20170101T1200Z"
-    data = np.array([6])
+    data = np.array([np.nan])
     forecast_df = _create_forecasts(
         forecast_reference_time, validity_time, data, representation="percentile"
     )
     forecast_df = _add_day_of_training_period(forecast_df)
 
     with pytest.raises(ValueError, match="All computed values for feature"):
-        prep_feature(forecast_df, variable_name, "std")
+        prep_feature(forecast_df, variable_name, "mean")
 
 
 @pytest.mark.parametrize(

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_quantile_regression_random_forest.py
@@ -256,8 +256,8 @@ def test_quantile_forest_package_available():
         ("percentile_50", np.tile([6, 8], 3).astype(np.float32), np.float32),
         ("members_below_5", np.repeat(1, 6).astype(np.float32), np.float32),
         ("members_above_5", np.repeat(2, 6).astype(np.float32), np.float32),
-        ("latitude", np.tile([50.1, 60.9], 3).astype(np.float32), np.float32),
-        ("longitude", np.tile([0.1, 10.9], 3).astype(np.float32), np.float32),
+        ("latitude", np.tile(LATITUDE, 3).astype(np.float32), np.float32),
+        ("longitude", np.tile(LONGITUDE, 3).astype(np.float32), np.float32),
         ("altitude", np.tile([10, 20], 3).astype(np.float32), np.float32),
         (
             "day_of_year",
@@ -388,8 +388,8 @@ def test_prep_feature_nan_exception():
         ("percentile_50", np.tile(np.array([6, 8], dtype=np.float32), 18), np.float32),
         ("members_below_5", np.repeat(1, 36).astype(np.float32), np.float32),
         ("members_above_5", np.repeat(2, 36).astype(np.float32), np.float32),
-        ("latitude", np.tile([50.1, 60.9], 18).astype(np.float32), np.float32),
-        ("longitude", np.tile([0.1, 10.9], 18).astype(np.float32), np.float32),
+        ("latitude", np.tile(LATITUDE, 18).astype(np.float32), np.float32),
+        ("longitude", np.tile(LONGITUDE, 18).astype(np.float32), np.float32),
         ("altitude", np.tile([10, 20], 18).astype(np.float32), np.float32),
         (
             "day_of_year",

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_quantile_regression_random_forest.py
@@ -256,8 +256,8 @@ def test_quantile_forest_package_available():
         ("percentile_50", np.tile([6, 8], 3).astype(np.float32), np.float32),
         ("members_below_5", np.repeat(1, 6).astype(np.float32), np.float32),
         ("members_above_5", np.repeat(2, 6).astype(np.float32), np.float32),
-        ("latitude", np.tile([50, 60], 3).astype(np.float32), np.float32),
-        ("longitude", np.tile([0, 10], 3).astype(np.float32), np.float32),
+        ("latitude", np.tile([50.1, 60.9], 3).astype(np.float32), np.float32),
+        ("longitude", np.tile([0.1, 10.9], 3).astype(np.float32), np.float32),
         ("altitude", np.tile([10, 20], 3).astype(np.float32), np.float32),
         (
             "day_of_year",
@@ -388,8 +388,8 @@ def test_prep_feature_std_exception():
         ("percentile_50", np.tile(np.array([6, 8], dtype=np.float32), 18), np.float32),
         ("members_below_5", np.repeat(1, 36).astype(np.float32), np.float32),
         ("members_above_5", np.repeat(2, 36).astype(np.float32), np.float32),
-        ("latitude", np.tile([50, 60], 18).astype(np.float32), np.float32),
-        ("longitude", np.tile([0, 10], 18).astype(np.float32), np.float32),
+        ("latitude", np.tile([50.1, 60.9], 18).astype(np.float32), np.float32),
+        ("longitude", np.tile([0.1, 10.9], 18).astype(np.float32), np.float32),
         ("altitude", np.tile([10, 20], 18).astype(np.float32), np.float32),
         (
             "day_of_year",

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_quantile_regression_random_forest.py
@@ -31,9 +31,9 @@ from improver.synthetic_data.set_up_test_cubes import set_up_spot_variable_cube
 
 pytest.importorskip("quantile_forest")
 
-ALTITUDE = [10, 20]
-LATITUDE = [50, 60]
-LONGITUDE = [0, 10]
+ALTITUDE = [10.0, 20.0]
+LATITUDE = [50.1, 60.9]
+LONGITUDE = [0.1, 10.9]
 WMO_ID = ["00001", "00002"]
 
 iris.FUTURE.pandas_ndim = True
@@ -71,9 +71,9 @@ def _create_forecasts(
         wmo_ids=WMO_ID,
         unique_site_id=WMO_ID,
         unique_site_id_key="station_id",
-        latitudes=np.array([50, 60], np.float32),
-        longitudes=np.array([0, 10], np.float32),
-        altitudes=np.array([10, 20], np.float32),
+        latitudes=np.array(LATITUDE, np.float32),
+        longitudes=np.array(LONGITUDE, np.float32),
+        altitudes=np.array(ALTITUDE, np.float32),
         time=dt.strptime(validity_time, DT_FORMAT),
         frt=dt.strptime(forecast_reference_time, DT_FORMAT),
     )
@@ -133,9 +133,9 @@ def _create_ancil_file(return_cube: bool = False) -> Cube | pd.DataFrame:
         wmo_ids=WMO_ID,
         unique_site_id=WMO_ID,
         unique_site_id_key="station_id",
-        latitudes=np.array([50, 60], np.float32),
-        longitudes=np.array([0, 10], np.float32),
-        altitudes=np.array([10, 20], np.float32),
+        latitudes=np.array(LATITUDE, np.float32),
+        longitudes=np.array(LONGITUDE, np.float32),
+        altitudes=np.array(ALTITUDE, np.float32),
         name="distance_to_water",
         units="m",
     )

--- a/improver_tests/calibration/test_init.py
+++ b/improver_tests/calibration/test_init.py
@@ -17,6 +17,7 @@ import pytest
 from iris.cube import CubeList
 
 from improver.calibration import (
+    add_static_feature_from_cube_to_df,
     add_warning_comment,
     get_common_wmo_ids,
     get_training_period_cycles,
@@ -1371,6 +1372,70 @@ def test_get_training_period_cycles(
     """Test that get_training_period_cycles returns the expected cycletimes."""
     result = get_training_period_cycles(cycletime, forecast_period, training_length)
     assert list(result) == expected
+
+
+@pytest.mark.parametrize(
+    "latitudes,longitudes,float_decimals",
+    (
+        ([5.0, 6.0, 7.0], [1.0, 2.0, 3.0], 4),
+        ([5.00001, 6.0, 7.0], [1.0, 2.0, 3.0], 4),
+        ([5.0001, 6.0, 7.0], [1.0, 2.0, 3.0], 4),
+    ),
+)
+@pytest.mark.parametrize("data", [[10, 20, 30], [1e-6, 2e-7, 3e-8]])
+@pytest.mark.parametrize("merge_columns", [["wmo_id"], ["latitude", "longitude"]])
+def test_add_static_feature_from_cube_to_df(
+    latitudes, longitudes, float_decimals, data, merge_columns
+):
+    """Test that a static feature from a cube is correctly added to a dataframe."""
+    data = np.array(data, dtype=np.float32)
+    static_cube = set_up_spot_variable_cube(
+        data,
+        wmo_ids=[1001, 1002, 1003],
+        latitudes=np.array(latitudes, dtype=np.float32),
+        longitudes=np.array(longitudes, dtype=np.float32),
+        name="distance_to_water",
+        units="m",
+    )
+    for coord in ["time", "forecast_reference_time", "forecast_period"]:
+        static_cube.remove_coord(coord)
+
+    data_dict = {
+        "wmo_id": ["01001", "01002", "01003"],
+        "latitude": static_cube.coord("latitude").points,
+        "longitude": static_cube.coord("longitude").points,
+        "forecast": [281, 272, 287],
+    }
+    data_df = pd.DataFrame(data_dict)
+
+    expected_distances = data
+    result_df = add_static_feature_from_cube_to_df(
+        data_df.copy(),
+        static_cube,
+        "distance_to_water",
+        possible_merge_columns=merge_columns,
+        float_decimals=float_decimals,
+    )
+
+    assert "distance_to_water" in result_df.columns
+    np.testing.assert_allclose(result_df["distance_to_water"], expected_distances)
+    for merge_column in merge_columns:
+        if merge_column == "latitude":
+            adjusted_latitudes = data_df[merge_column]
+            if latitudes[0] == 5.00001:
+                # Rounding means that 5.00001 becomes 5.0 when float_decimals=4
+                adjusted_latitudes = [5.0, 6.0, 7.0]
+            np.testing.assert_allclose(
+                result_df[merge_column],
+                adjusted_latitudes,
+            )
+        elif merge_column == "longitude":
+            np.testing.assert_allclose(
+                result_df[merge_column],
+                data_df[merge_column],
+            )
+        else:
+            np.array_equal(result_df[merge_column], data_df[merge_column])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Related to https://github.com/metoppv/improver/pull/2214

Description
This PR builds on https://github.com/metoppv/improver/pull/2214 by:

- Factoring out the removal of NaNs from the forecast DataFrame into a function.
- Correction to unit tests, so the wind direction has a `representation` column with NaNs.
- Create a function primarily to support merging between inputs, in both train and apply, when using e.g. latitude and longitude to identify sites, rather than e.g. WMO ID. As latitude and longitude are floats, this can cause precision issues.
- Added an exception when preparing the features, so that if NaNs results, this will cause an exception. An example of this is when computing the mean using a single point with a value of NaN. This generates NaN, which now results in an exception. For standard deviations, if all values are the same, the standard deviation would give a NaN. As it is theoretically possible that an ensemble could forecast the same value across all members at a particular grid point, this could generate a NaN for the standard deviation, which could introduce a NaN into the training. As NaNs in the training are undesirable, NaNs found after computing the standard deviation are filled with zeroes.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)